### PR TITLE
feature: Integrar módulo de CloudFront y conectar con bucket

### DIFF
--- a/iac/main.tf
+++ b/iac/main.tf
@@ -28,3 +28,11 @@ module "cognito" {
   callback_urls = ["http://localhost:3000/callback"]
   logout_urls   = ["http://localhost:3000/logout"]
 }
+
+module "cloudfront" {
+  source             = "./modules/cloudfront"
+  environment        = var.environment
+  bucket_name        = module.s3_web.bucket_name
+  bucket_domain_name = module.s3_web.bucket_domain_name
+  bucket_arn         = module.s3_web.bucket_arn
+}

--- a/iac/modules/cloudfront/main.tf
+++ b/iac/modules/cloudfront/main.tf
@@ -1,0 +1,71 @@
+resource "aws_cloudfront_origin_access_identity" "oai" {
+  comment = "Access Identity for CloudFront to access S3 bucket"
+}
+
+resource "aws_cloudfront_distribution" "cdn" {
+  origin {
+    domain_name = var.bucket_domain_name
+    origin_id   = "S3-Bucket-Origin"
+
+    s3_origin_config {
+      origin_access_identity = aws_cloudfront_origin_access_identity.oai.cloudfront_access_identity_path
+    }
+  }
+
+  enabled             = true
+  default_root_object = "index.html"
+
+  default_cache_behavior {
+    allowed_methods  = ["GET", "HEAD"]
+    cached_methods   = ["GET", "HEAD"]
+    target_origin_id = "S3-Bucket-Origin"
+
+    forwarded_values {
+      query_string = false
+      cookies {
+        forward = "none"
+      }
+    }
+
+    viewer_protocol_policy = "redirect-to-https"
+  }
+
+  viewer_certificate {
+    cloudfront_default_certificate = true
+  }
+
+  restrictions {
+    geo_restriction {
+      restriction_type = "none"
+    }
+  }
+
+  tags = {
+    Name        = "OnlineReady-CDN"
+    Environment = var.environment
+  }
+}
+
+resource "aws_s3_bucket_policy" "bucket_policy" {
+  bucket = var.bucket_name
+
+  policy = jsonencode({
+    Version = "2012-10-17",
+    Statement = [
+      {
+        Sid    = "AllowCloudFrontAccess",
+        Effect = "Allow",
+        Principal = {
+          Service = "cloudfront.amazonaws.com"
+        },
+        Action   = "s3:GetObject",
+        Resource = "${var.bucket_arn}/*",
+        Condition = {
+          StringEquals = {
+            "AWS:SourceArn" = aws_cloudfront_distribution.cdn.arn
+          }
+        }
+      }
+    ]
+  })
+}

--- a/iac/modules/cloudfront/outputs.tf
+++ b/iac/modules/cloudfront/outputs.tf
@@ -1,0 +1,9 @@
+output "cloudfront_distribution_id" {
+  description = "ID de la distribución de CloudFront"
+  value       = aws_cloudfront_distribution.cdn.id
+}
+
+output "cloudfront_domain_name" {
+  description = "Dominio asignado a la distribución de CloudFront"
+  value       = aws_cloudfront_distribution.cdn.domain_name
+}

--- a/iac/modules/cloudfront/variables.tf
+++ b/iac/modules/cloudfront/variables.tf
@@ -1,0 +1,19 @@
+variable "bucket_domain_name" {
+  description = "Dominio del bucket S3"
+  type        = string
+}
+
+variable "environment" {
+  description = "Ambiente de despliegue (dev, prod)"
+  type        = string
+}
+
+variable "bucket_name" {
+  description = "Nombre del bucket S3"
+  type        = string
+}
+
+variable "bucket_arn" {
+  description = "ARN del bucket S3"
+  type        = string
+}


### PR DESCRIPTION
Este pull request integra un módulo de CloudFront a la infraestructura usando Terraform.

- Se crea el módulo `cloudfront` con variables para recibir información del bucket S3 y el entorno.
- Se definen outputs para exponer el ID y dominio de la distribución de CloudFront.
- Se actualiza `main.tf` para instanciar el módulo y conectarlo con el bucket S3 como origen.

## Motivación

Permite servir contenido estático del bucket S3 a través de CloudFront, mejorando el rendimiento y la seguridad del acceso a los archivos.

## Cambios principales

- Nuevo módulo `cloudfront` con variables y outputs.
- Integración del módulo en el archivo principal de Terraform.
- Parametrización del entorno de despliegue.