### PR TITLE
feature: Integración de buckets con S3 para almacenamiento de archivos

### DIFF
--- a/iac/main.tf
+++ b/iac/main.tf
@@ -168,9 +168,34 @@ module "rds_usuarios" {
   security_group_id    = module.vpc.database_security_group_id  
   environment          = var.environment
 }
-
 module "s3_public" {
   source       = "./modules/s3_bucket/s3_public"
   bucket_name  = "online-ready-public-${var.environment}"
+  environment  = var.environment
+}
+
+module "lambda_users" {
+  source         = "./modules/lambdas/users"
+  role_arn       = module.iam_lambda_users.role_arn
+  db_host        = module.rds_usuarios.endpoint
+  db_name        = module.rds_usuarios.name
+  db_user        = "admin"
+  db_password    = "supersecure"
+  s3_public_url  = "https://${module.s3_public.bucket_name}.s3.amazonaws.com"
+  environment    = var.environment
+}
+
+module "rds_curso_docente" {
+  source               = "./modules/rds/curso_docente"
+  db_user              = "dbadmin"
+  db_password          = "supersecure"
+  db_subnet_group_name = module.vpc.db_subnet_group_name
+  security_group_id    = module.vpc.database_security_group_id
+  environment          = var.environment
+}
+
+module "s3_cursos_privados" {
+  source       = "./modules/s3_bucket/s3_cursos_privados"
+  bucket_name  = "online-ready-cursos-${var.environment}"
   environment  = var.environment
 }

--- a/iac/main.tf
+++ b/iac/main.tf
@@ -42,3 +42,104 @@ module "s3_web" {
   bucket_name  = "online-ready-web-${var.environment}"
   environment  = var.environment
 }
+
+module "api_gateway" {
+  source                      = "./modules/api_gateway"
+  api_name                    = "OnlineReadyAPI"
+  api_description             = "API for interacting with DynamoDB"
+  lambda_notify_invoke_arn    = module.lambda_notify.invoke_arn
+  lambda_notify_function_name = module.lambda_notify.function_name
+  lambda_cursos_invoke_arn    = module.lambda_courses.invoke_arn
+}
+
+module "lambda_api_handler" {
+  source              = "./modules/lambdas/api_handler"
+  role_arn            = module.iam_roles.api_handler_role_arn
+  dynamodb_table_name = module.dynamodb_archivos.table_name
+  environment         = var.environment
+}
+
+module "iam_roles" {
+  source = "./modules/iam_roles/iam_roles"
+  s3_bucket_arn      = module.s3_archivos.bucket_arn
+  dynamodb_table_arn = module.dynamodb_archivos.table_arn
+  rds_instance_arn   = module.rds_usuarios.arn 
+  environment        = var.environment
+}
+
+module "lambda_notify" {
+  source      = "./modules/lambdas/notify"
+  role_arn    = module.iam_roles.lambda_notify_role_arn
+  environment = var.environment
+}
+
+module "cloudwatch_logs_notify" {
+  source         = "./modules/monitoring/cloudwatch_logs"
+  environment    = var.environment
+  retention_days = 14
+}
+
+# SQS
+module "sqs_files" {
+  source = "./modules/sqs_files"
+  environment = var.environment
+}
+
+# Lambda Files Messenger 
+module "iam_files_messenger" {
+  source        = "./modules/iam_roles/lambda_exec_role"
+  role_name     = "lambda-files-messenger-role"
+  s3_bucket_arn = module.s3_archivos.bucket_arn
+  dynamodb_table_arn = module.dynamodb_archivos.table_arn
+  rds_instance_arn   = module.rds_usuarios.arn
+}
+
+# SNS para notificación
+module "sns_files" {
+  source         = "./modules/sns_files"
+  email_receiver = "vascofrann@gmail.com"
+}
+# Módulo para crear tablas DynamoDB
+module "dynamodb" {
+  source      = "./modules/dynamodb"
+}
+
+module "dynamodb_archivos" {
+  source      = "./modules/dynamodb/dynamodb_archivos"
+  environment = var.environment
+}
+
+module "dynamodb_metadatos_cursos" {
+  source      = "./modules//dynamodb/dynamodb_metadatos_cursos"
+  environment = var.environment
+}
+
+module "dynamodb_dax" {
+  source        = "./modules/dynamodb/dynamodb_dax"
+  dax_role_arn  = aws_iam_role.dax_service_role.arn
+  environment   = var.environment
+}
+
+# Crear rol DAX
+resource "aws_iam_role" "dax_service_role" {
+  name = "dax-service-role-${var.environment}"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Action = "sts:AssumeRole"
+        Effect = "Allow"
+        Principal = {
+          Service = "dax.amazonaws.com"
+        }
+      }
+    ]
+  })
+}
+
+module "s3_archivos" {
+  source       = "./modules/s3_bucket/s3_archivos"
+  bucket_name  = "online-ready-archivos-${var.environment}"
+  environment  = var.environment
+}

--- a/iac/main.tf
+++ b/iac/main.tf
@@ -143,3 +143,34 @@ module "s3_archivos" {
   bucket_name  = "online-ready-archivos-${var.environment}"
   environment  = var.environment
 }
+
+module "lambda_files_manager" {
+  source              = "./modules/lambdas/files_manager"
+  role_arn            = module.iam_lambda_files_manager.role_arn
+  s3_bucket_name      = module.s3_archivos.bucket_name
+  dynamodb_table_name = module.dynamodb_archivos.table_name
+  environment         = var.environment
+}
+
+module "iam_lambda_files_manager" {
+  source             = "./modules/iam_roles/lambda_exec_role"
+  role_name          = "lambda-files-manager-role"
+  s3_bucket_arn      = module.s3_archivos.bucket_arn
+  dynamodb_table_arn = module.dynamodb_archivos.table_arn
+  rds_instance_arn   = module.rds_usuarios.arn
+}
+
+module "rds_usuarios" {
+  source               = "./modules/rds/usuarios"
+  db_user              = "dbadmin"
+  db_password          = "supersecure"
+  db_subnet_group_name = module.vpc.db_subnet_group_name  
+  security_group_id    = module.vpc.database_security_group_id  
+  environment          = var.environment
+}
+
+module "s3_public" {
+  source       = "./modules/s3_bucket/s3_public"
+  bucket_name  = "online-ready-public-${var.environment}"
+  environment  = var.environment
+}

--- a/iac/main.tf
+++ b/iac/main.tf
@@ -36,3 +36,9 @@ module "cloudfront" {
   bucket_domain_name = module.s3_web.bucket_domain_name
   bucket_arn         = module.s3_web.bucket_arn
 }
+
+module "s3_web" {
+  source       = "./modules/s3_bucket/s3_web"
+  bucket_name  = "online-ready-web-${var.environment}"
+  environment  = var.environment
+}

--- a/iac/main.tf
+++ b/iac/main.tf
@@ -28,3 +28,11 @@ module "cognito" {
   callback_urls = ["http://localhost:3000/callback"]
   logout_urls   = ["http://localhost:3000/logout"]
 }
+
+module "cloudfront" {
+  source             = "./modules/cloudfront"
+  environment        = var.environment
+  bucket_name        = module.s3_web.bucket_name
+  bucket_domain_name = module.s3_web.bucket_domain_name
+  bucket_arn         = module.s3_web.bucket_arn
+}

--- a/iac/modules/cloudfront/main.tf
+++ b/iac/modules/cloudfront/main.tf
@@ -1,0 +1,71 @@
+resource "aws_cloudfront_origin_access_identity" "oai" {
+  comment = "Access Identity for CloudFront to access S3 bucket"
+}
+
+resource "aws_cloudfront_distribution" "cdn" {
+  origin {
+    domain_name = var.bucket_domain_name
+    origin_id   = "S3-Bucket-Origin"
+
+    s3_origin_config {
+      origin_access_identity = aws_cloudfront_origin_access_identity.oai.cloudfront_access_identity_path
+    }
+  }
+
+  enabled             = true
+  default_root_object = "index.html"
+
+  default_cache_behavior {
+    allowed_methods  = ["GET", "HEAD"]
+    cached_methods   = ["GET", "HEAD"]
+    target_origin_id = "S3-Bucket-Origin"
+
+    forwarded_values {
+      query_string = false
+      cookies {
+        forward = "none"
+      }
+    }
+
+    viewer_protocol_policy = "redirect-to-https"
+  }
+
+  viewer_certificate {
+    cloudfront_default_certificate = true
+  }
+
+  restrictions {
+    geo_restriction {
+      restriction_type = "none"
+    }
+  }
+
+  tags = {
+    Name        = "OnlineReady-CDN"
+    Environment = var.environment
+  }
+}
+
+resource "aws_s3_bucket_policy" "bucket_policy" {
+  bucket = var.bucket_name
+
+  policy = jsonencode({
+    Version = "2012-10-17",
+    Statement = [
+      {
+        Sid    = "AllowCloudFrontAccess",
+        Effect = "Allow",
+        Principal = {
+          Service = "cloudfront.amazonaws.com"
+        },
+        Action   = "s3:GetObject",
+        Resource = "${var.bucket_arn}/*",
+        Condition = {
+          StringEquals = {
+            "AWS:SourceArn" = aws_cloudfront_distribution.cdn.arn
+          }
+        }
+      }
+    ]
+  })
+}

--- a/iac/modules/cloudfront/outputs.tf
+++ b/iac/modules/cloudfront/outputs.tf
@@ -1,0 +1,9 @@
+output "cloudfront_distribution_id" {
+  description = "ID de la distribución de CloudFront"
+  value       = aws_cloudfront_distribution.cdn.id
+}
+
+output "cloudfront_domain_name" {
+  description = "Dominio asignado a la distribución de CloudFront"
+  value       = aws_cloudfront_distribution.cdn.domain_name
+}

--- a/iac/modules/cloudfront/variables.tf
+++ b/iac/modules/cloudfront/variables.tf
@@ -1,0 +1,19 @@
+variable "bucket_domain_name" {
+  description = "Dominio del bucket S3"
+  type        = string
+}
+
+variable "environment" {
+  description = "Ambiente de despliegue (dev, prod)"
+  type        = string
+}
+
+variable "bucket_name" {
+  description = "Nombre del bucket S3"
+  type        = string
+}
+
+variable "bucket_arn" {
+  description = "ARN del bucket S3"
+  type        = string
+}

--- a/iac/modules/s3_bucket/s3_archivos/main.tf
+++ b/iac/modules/s3_bucket/s3_archivos/main.tf
@@ -1,0 +1,8 @@
+resource "aws_s3_bucket" "private" {
+  bucket = var.bucket_name
+
+  tags = {
+    Name        = var.bucket_name
+    Environment = var.environment
+  }
+}

--- a/iac/modules/s3_bucket/s3_archivos/outputs.tf
+++ b/iac/modules/s3_bucket/s3_archivos/outputs.tf
@@ -1,0 +1,7 @@
+output "bucket_name" {
+  value = aws_s3_bucket.private.bucket
+}
+
+output "bucket_arn" {
+  value = aws_s3_bucket.private.arn
+}

--- a/iac/modules/s3_bucket/s3_archivos/variables.tf
+++ b/iac/modules/s3_bucket/s3_archivos/variables.tf
@@ -1,0 +1,9 @@
+variable "bucket_name" {
+  description = "Nombre del bucket S3 privado"
+  type        = string
+}
+
+variable "environment" {
+  description = "Ambiente de despliegue"
+  type        = string
+}

--- a/iac/modules/s3_bucket/s3_cursos_privados/main.tf
+++ b/iac/modules/s3_bucket/s3_cursos_privados/main.tf
@@ -1,0 +1,13 @@
+resource "aws_s3_bucket" "private" {
+  bucket = var.bucket_name
+
+  website {
+    index_document = "index.html"
+    error_document = "error.html"
+  }
+
+  tags = {
+    Name        = var.bucket_name
+    Environment = var.environment
+  }
+}

--- a/iac/modules/s3_bucket/s3_cursos_privados/outputs.tf
+++ b/iac/modules/s3_bucket/s3_cursos_privados/outputs.tf
@@ -1,0 +1,7 @@
+output "bucket_name" {
+  value = aws_s3_bucket.private.bucket
+}
+
+output "bucket_arn" {
+  value = aws_s3_bucket.private.arn
+}

--- a/iac/modules/s3_bucket/s3_cursos_privados/variables.tf
+++ b/iac/modules/s3_bucket/s3_cursos_privados/variables.tf
@@ -1,0 +1,9 @@
+variable "bucket_name" {
+  description = "Nombre del bucket S3 privado"
+  type        = string
+}
+
+variable "environment" {
+  description = "Ambiente de despliegue"
+  type        = string
+}

--- a/iac/modules/s3_bucket/s3_public/main.tf
+++ b/iac/modules/s3_bucket/s3_public/main.tf
@@ -1,0 +1,13 @@
+resource "aws_s3_bucket" "public" {
+  bucket = var.bucket_name
+
+  website {
+    index_document = "index.html"
+    error_document = "error.html"
+  }
+
+  tags = {
+    Name        = var.bucket_name
+    Environment = var.environment
+  }
+}

--- a/iac/modules/s3_bucket/s3_public/outputs.tf
+++ b/iac/modules/s3_bucket/s3_public/outputs.tf
@@ -1,0 +1,7 @@
+output "bucket_name" {
+  value = aws_s3_bucket.public.bucket
+}
+
+output "bucket_arn" {
+  value = aws_s3_bucket.public.arn
+}

--- a/iac/modules/s3_bucket/s3_public/variables.tf
+++ b/iac/modules/s3_bucket/s3_public/variables.tf
@@ -1,0 +1,9 @@
+variable "bucket_name" {
+  description = "Nombre del bucket S3 público"
+  type        = string
+}
+
+variable "environment" {
+  description = "Ambiente de despliegue (dev, prod)"
+  type        = string
+}

--- a/iac/modules/s3_bucket/s3_web/main.tf
+++ b/iac/modules/s3_bucket/s3_web/main.tf
@@ -1,0 +1,23 @@
+resource "aws_s3_bucket" "bucket" {
+  bucket = var.bucket_name
+  # acl    = "public-read"
+
+  website {
+    index_document = "index.html"
+    error_document = "error.html"
+  }
+
+  tags = {
+    Name        = var.bucket_name
+    Environment = var.environment
+  }
+}
+
+resource "aws_s3_bucket_public_access_block" "block_public_access" {
+  bucket = aws_s3_bucket.bucket.id
+
+  block_public_acls   = false
+  block_public_policy = false
+  ignore_public_acls  = false
+  restrict_public_buckets = false
+}

--- a/iac/modules/s3_bucket/s3_web/outputs.tf
+++ b/iac/modules/s3_bucket/s3_web/outputs.tf
@@ -1,0 +1,14 @@
+output "bucket_name" {
+  description = "Nombre del bucket creado"
+  value       = aws_s3_bucket.bucket.id
+}
+
+output "bucket_domain_name" {
+  description = "Dominio regional del bucket"
+  value       = aws_s3_bucket.bucket.bucket_regional_domain_name
+}
+
+output "bucket_arn" {
+  description = "ARN del bucket"
+  value       = aws_s3_bucket.bucket.arn
+}

--- a/iac/modules/s3_bucket/s3_web/variables.tf
+++ b/iac/modules/s3_bucket/s3_web/variables.tf
@@ -1,0 +1,9 @@
+variable "bucket_name" {
+  description = "Nombre del bucket S3 público para web hosting"
+  type        = string
+}
+
+variable "environment" {
+  description = "Ambiente de despliegue"
+  type        = string
+}


### PR DESCRIPTION
Los cambios incluyen la adición de módulos para S3 buckets, distribuciones de CloudFront, tablas DynamoDB, roles IAM y otros servicios de apoyo de AWS. 
- Se añadieron módulos para buckets privados (s3_archivos), públicos (s3_public) y de alojamiento web (s3_web), cada uno con configuraciones adecuadas para su caso de uso.
- Se introdujo un módulo de CloudFront para servir contenido de manera segura desde el bucket s3_web, incluyendo una identidad de acceso de origen (OAI) y un comportamiento de caché por defecto con redirección HTTPS.
- Se añadieron módulos para crear tablas DynamoDB (dynamodb_archivos, dynamodb_metadatos_cursos) y un clúster DAX para almacenamiento en caché. 
- Se provisionaron instancias RDS para el almacenamiento de datos de usuarios y cursos con configuraciones asociadas de grupos de seguridad.
- Se configuraron políticas de bucket S3 para permitir el acceso desde distribuciones de CloudFront y otros servicios de AWS según sea necesario.