### PR TITLE
feature: Integración de API Gateway para alojamiento web estático

### DIFF
--- a/iac/main.tf
+++ b/iac/main.tf
@@ -42,3 +42,12 @@ module "s3_web" {
   bucket_name  = "online-ready-web-${var.environment}"
   environment  = var.environment
 }
+
+module "api_gateway" {
+  source                      = "./modules/api_gateway"
+  api_name                    = "OnlineReadyAPI"
+  api_description             = "API for interacting with DynamoDB"
+  lambda_notify_invoke_arn    = module.lambda_notify.invoke_arn
+  lambda_notify_function_name = module.lambda_notify.function_name
+  lambda_cursos_invoke_arn    = module.lambda_courses.invoke_arn
+}

--- a/iac/modules/api_gateway/main.tf
+++ b/iac/modules/api_gateway/main.tf
@@ -1,0 +1,34 @@
+resource "aws_api_gateway_resource" "notify_resource" {
+  rest_api_id = aws_api_gateway_rest_api.api.id
+  parent_id   = aws_api_gateway_rest_api.api.root_resource_id
+  path_part   = "notify"
+}
+
+resource "aws_api_gateway_method" "notify_post" {
+  rest_api_id   = aws_api_gateway_rest_api.api.id
+  resource_id   = aws_api_gateway_resource.notify_resource.id
+  http_method   = "POST"
+  authorization = "NONE"
+}
+
+resource "aws_api_gateway_integration" "notify_post_integration" {
+  rest_api_id             = aws_api_gateway_rest_api.api.id
+  resource_id             = aws_api_gateway_resource.notify_resource.id
+  http_method             = aws_api_gateway_method.notify_post.http_method
+  integration_http_method = "POST"
+  type                    = "AWS_PROXY"
+  uri                     = var.lambda_notify_invoke_arn
+}
+
+resource "aws_lambda_permission" "allow_api_gateway" {
+  statement_id  = "AllowExecutionFromAPIGateway"
+  action        = "lambda:InvokeFunction"
+  function_name = var.lambda_notify_function_name
+  principal     = "apigateway.amazonaws.com"
+  source_arn    = "${aws_api_gateway_rest_api.api.execution_arn}/*/*"
+}
+
+resource "aws_api_gateway_rest_api" "api" {
+  name        = var.api_name
+  description = var.api_description
+}

--- a/iac/modules/api_gateway/outputs.tf
+++ b/iac/modules/api_gateway/outputs.tf
@@ -1,0 +1,11 @@
+output "api_id" {
+  value = aws_api_gateway_rest_api.api.id
+}
+
+output "root_resource_id" {
+  value = aws_api_gateway_rest_api.api.root_resource_id
+}
+
+output "execution_arn" {
+  value = aws_api_gateway_rest_api.api.execution_arn
+}

--- a/iac/modules/api_gateway/variables.tf
+++ b/iac/modules/api_gateway/variables.tf
@@ -1,0 +1,24 @@
+variable "lambda_notify_invoke_arn" {
+  description = "ARN de invocación de la Lambda asociada a /notify"
+  type        = string
+}
+
+variable "lambda_notify_function_name" {
+  description = "Nombre de la Lambda que maneja /notify"
+  type        = string
+}
+
+variable "api_name" {
+  description = "Nombre del API Gateway"
+  type        = string
+}
+
+variable "api_description" {
+  description = "Descripción del API Gateway"
+  type        = string
+}
+
+variable "lambda_cursos_invoke_arn" {
+  description = "ARN de invocación para Lambda Cursos"
+  type        = string
+}


### PR DESCRIPTION
En este pull request, los cambios incluyen la adición de módulos para S3, CloudFront y API Gateway, habilitando el alojamiento web estático, la entrega de contenido y la gestión de API.
- Se añadió un módulo de bucket S3 (iac/modules/s3_bucket/s3_web/main.tf) configurado para alojamiento de sitios web estáticos con index.html y error.html. El acceso público está parcialmente bloqueado por razones de seguridad.
- Se configuró una distribución de CloudFront (iac/modules/cloudfront/main.tf) para servir contenido desde el bucket S3, forzando HTTPS.
- Se añadió un módulo de API Gateway (iac/modules/api_gateway/main.tf) con un recurso /notify y método POST integrado con una función Lambda utilizando AWS_PROXY.
- Se integraron los nuevos módulos de S3, CloudFront y API Gateway en la configuración principal de Terraform (iac/main.tf) para un despliegue sin problemas.