### PR TITLE
feature: Integración de tablas con DynamoDB con DAX para gestión de datos

### DIFF
--- a/iac/main.tf
+++ b/iac/main.tf
@@ -103,3 +103,8 @@ module "sns_files" {
 module "dynamodb" {
   source      = "./modules/dynamodb"
 }
+
+module "dynamodb_archivos" {
+  source      = "./modules/dynamodb/dynamodb_archivos"
+  environment = var.environment
+}

--- a/iac/main.tf
+++ b/iac/main.tf
@@ -99,3 +99,7 @@ module "sns_files" {
   source         = "./modules/sns_files"
   email_receiver = "vascofrann@gmail.com"
 }
+# Módulo para crear tablas DynamoDB
+module "dynamodb" {
+  source      = "./modules/dynamodb"
+}

--- a/iac/main.tf
+++ b/iac/main.tf
@@ -119,3 +119,21 @@ module "dynamodb_dax" {
   dax_role_arn  = aws_iam_role.dax_service_role.arn
   environment   = var.environment
 }
+
+# Crear rol DAX
+resource "aws_iam_role" "dax_service_role" {
+  name = "dax-service-role-${var.environment}"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Action = "sts:AssumeRole"
+        Effect = "Allow"
+        Principal = {
+          Service = "dax.amazonaws.com"
+        }
+      }
+    ]
+  })
+}

--- a/iac/main.tf
+++ b/iac/main.tf
@@ -57,8 +57,6 @@ module "lambda_api_handler" {
   role_arn            = module.iam_roles.api_handler_role_arn
   dynamodb_table_name = module.dynamodb_archivos.table_name
   environment         = var.environment
-<<<<<<< Updated upstream
-=======
 }
 
 module "iam_roles" {
@@ -73,9 +71,6 @@ module "lambda_notify" {
   source      = "./modules/lambdas/notify"
   role_arn    = module.iam_roles.lambda_notify_role_arn
   environment = var.environment
-<<<<<<< Updated upstream
->>>>>>> Stashed changes
-=======
 }
 
 module "cloudwatch_logs_notify" {
@@ -97,5 +92,10 @@ module "iam_files_messenger" {
   s3_bucket_arn = module.s3_archivos.bucket_arn
   dynamodb_table_arn = module.dynamodb_archivos.table_arn
   rds_instance_arn   = module.rds_usuarios.arn
->>>>>>> Stashed changes
+}
+
+# SNS para notificación
+module "sns_files" {
+  source         = "./modules/sns_files"
+  email_receiver = "vascofrann@gmail.com"
 }

--- a/iac/main.tf
+++ b/iac/main.tf
@@ -108,3 +108,8 @@ module "dynamodb_archivos" {
   source      = "./modules/dynamodb/dynamodb_archivos"
   environment = var.environment
 }
+
+module "dynamodb_metadatos_cursos" {
+  source      = "./modules//dynamodb/dynamodb_metadatos_cursos"
+  environment = var.environment
+}

--- a/iac/main.tf
+++ b/iac/main.tf
@@ -113,3 +113,9 @@ module "dynamodb_metadatos_cursos" {
   source      = "./modules//dynamodb/dynamodb_metadatos_cursos"
   environment = var.environment
 }
+
+module "dynamodb_dax" {
+  source        = "./modules/dynamodb/dynamodb_dax"
+  dax_role_arn  = aws_iam_role.dax_service_role.arn
+  environment   = var.environment
+}

--- a/iac/modules/dynamodb/dynamodb_archivos/main.tf
+++ b/iac/modules/dynamodb/dynamodb_archivos/main.tf
@@ -1,0 +1,15 @@
+resource "aws_dynamodb_table" "registro_archivos" {
+  name           = "registro_archivos"
+  billing_mode   = "PAY_PER_REQUEST"
+  hash_key       = "archivo_id"
+
+  attribute {
+    name = "archivo_id"
+    type = "S"
+  }
+
+  tags = {
+    Name        = "registro_archivos"
+    Environment = var.environment
+  }
+}

--- a/iac/modules/dynamodb/dynamodb_archivos/outputs.tf
+++ b/iac/modules/dynamodb/dynamodb_archivos/outputs.tf
@@ -1,0 +1,7 @@
+output "table_name" {
+  value = aws_dynamodb_table.registro_archivos.name
+}
+
+output "table_arn" {
+  value = aws_dynamodb_table.registro_archivos.arn
+}

--- a/iac/modules/dynamodb/dynamodb_archivos/variables.tf
+++ b/iac/modules/dynamodb/dynamodb_archivos/variables.tf
@@ -1,0 +1,4 @@
+variable "environment" {
+  description = "Ambiente"
+  type        = string
+}

--- a/iac/modules/dynamodb/dynamodb_dax/main.tf
+++ b/iac/modules/dynamodb/dynamodb_dax/main.tf
@@ -1,0 +1,11 @@
+resource "aws_dax_cluster" "dax_cluster" {
+  cluster_name = "curso-dax-cluster"
+  node_type    = "dax.r4.large"
+  replication_factor = 3
+  iam_role_arn = var.dax_role_arn
+
+  tags = {
+    Name        = "CursoDAX"
+    Environment = var.environment
+  }
+}

--- a/iac/modules/dynamodb/dynamodb_dax/outputs.tf
+++ b/iac/modules/dynamodb/dynamodb_dax/outputs.tf
@@ -1,0 +1,8 @@
+output "dax_cluster_arn" {
+  value = aws_dax_cluster.dax_cluster.arn
+}
+
+output "dax_endpoint" {
+  description = "DAX cluster endpoint"
+  value       = aws_dax_cluster.dax_cluster.cluster_address
+}

--- a/iac/modules/dynamodb/dynamodb_dax/variables.tf
+++ b/iac/modules/dynamodb/dynamodb_dax/variables.tf
@@ -1,0 +1,9 @@
+variable "dax_role_arn" {
+  description = "ARN del rol de IAM para DAX"
+  type        = string
+}
+
+variable "environment" {
+  description = "Ambiente de despliegue"
+  type        = string
+}

--- a/iac/modules/dynamodb/dynamodb_metadatos_cursos/main.tf
+++ b/iac/modules/dynamodb/dynamodb_metadatos_cursos/main.tf
@@ -1,0 +1,15 @@
+resource "aws_dynamodb_table" "metadatos_cursos" {
+  name           = "metadatos_cursos"
+  billing_mode   = "PAY_PER_REQUEST"
+  hash_key       = "curso_id"
+
+  attribute {
+    name = "curso_id"
+    type = "S"
+  }
+
+  tags = {
+    Name        = "MetadatosCursos"
+    Environment = var.environment
+  }
+}

--- a/iac/modules/dynamodb/dynamodb_metadatos_cursos/outputs.tf
+++ b/iac/modules/dynamodb/dynamodb_metadatos_cursos/outputs.tf
@@ -1,0 +1,7 @@
+output "table_name" {
+  value = aws_dynamodb_table.metadatos_cursos.name
+}
+
+output "table_arn" {
+  value = aws_dynamodb_table.metadatos_cursos.arn
+}

--- a/iac/modules/dynamodb/dynamodb_metadatos_cursos/variables.tf
+++ b/iac/modules/dynamodb/dynamodb_metadatos_cursos/variables.tf
@@ -1,0 +1,4 @@
+variable "environment" {
+  description = "Ambiente"
+  type        = string
+}

--- a/iac/modules/sns_files/main.tf
+++ b/iac/modules/sns_files/main.tf
@@ -1,0 +1,9 @@
+resource "aws_sns_topic" "files_topic" {
+  name = "files-notification-topic"
+}
+
+resource "aws_sns_topic_subscription" "email_alert" {
+  topic_arn = aws_sns_topic.files_topic.arn
+  protocol  = "email"
+  endpoint  = var.email_receiver  # ejemplo: tu_correo@correo.com
+}

--- a/iac/modules/sns_files/variables.tf
+++ b/iac/modules/sns_files/variables.tf
@@ -1,0 +1,4 @@
+variable "email_receiver" {
+  description = "Correo electrónico para recibir las notificaciones de SNS"
+  type        = string
+}


### PR DESCRIPTION
En este pull request se integra el servicio DynamoDB a través de tablas y base de datos escalable con cacheo en memoria para mejorar el rendimiento de consultas frecuentes en el sistema de cursos online.
- Se introdujeron varias tablas DynamoDB (`dynamodb_archivos`, `dynamodb_metadatos_cursos`) y un clúster DAX (`dynamodb_dax`) para almacenamiento de datos eficiente y almacenamiento en caché.
- Se configuraron roles IAM para las funciones Lambda y DAX, asegurando el acceso con privilegios mínimos a recursos como S3, DynamoDB.
- Con la integración, permite ser compatible con `lambda_function` para operaciones CRUD
