### PR TITLE
feature: Módulo VPC con subredes públicas/privadas, DB Subnet Group y Security Group para RDS

### DIFF
--- a/iac/main.tf
+++ b/iac/main.tf
@@ -227,3 +227,13 @@ module "iam_lambda_users" {
   dynamodb_table_arn = module.dynamodb_archivos.table_arn
   rds_instance_arn   = module.rds_usuarios.arn
 }
+
+module "vpc" {
+  source                     = "./modules/vpc"
+  cidr_block                 = "10.0.0.0/16"
+  public_subnet_cidr         = "10.0.1.0/24"
+  private_subnet_cidr        = "10.0.2.0/24"
+  availability_zone          = "us-east-2a"
+  private_availability_zone  = "us-east-2b"
+  environment                = var.environment
+}

--- a/iac/modules/vpc/main.tf
+++ b/iac/modules/vpc/main.tf
@@ -1,0 +1,81 @@
+# Crear la VPC
+resource "aws_vpc" "main" {
+  cidr_block = var.cidr_block
+
+  enable_dns_support   = true
+  enable_dns_hostnames = true
+
+  tags = {
+    Name        = "OnlineReadyVPC"
+    Environment = var.environment
+  }
+}
+
+# Crear una subnet pública
+resource "aws_subnet" "public" {
+  vpc_id                  = aws_vpc.main.id
+  cidr_block              = var.public_subnet_cidr
+  availability_zone       = var.availability_zone
+  map_public_ip_on_launch = true
+
+  tags = {
+    Name        = "OnlineReadyPublicSubnet"
+    Environment = var.environment
+  }
+}
+
+# Crear una subnet privada 
+resource "aws_subnet" "private" {
+  vpc_id            = aws_vpc.main.id
+  cidr_block        = var.private_subnet_cidr
+  availability_zone = var.private_availability_zone
+
+  tags = {
+    Name        = "OnlineReadyPrivateSubnet"
+    Environment = var.environment
+  }
+}
+
+# Crear un Internet Gateway
+resource "aws_internet_gateway" "main" {
+  vpc_id = aws_vpc.main.id
+
+  tags = {
+    Name        = "OnlineReadyInternetGateway"
+    Environment = var.environment
+  }
+}
+resource "aws_db_subnet_group" "main" {
+  name       = "my-db-subnet"
+  subnet_ids = [aws_subnet.public.id, aws_subnet.private.id]
+
+  tags = {
+    Name        = "OnlineReady-DB-SubnetGroup"
+    Environment = var.environment
+  }
+}
+
+# Security Group para RDS
+resource "aws_security_group" "database" {
+  name_prefix = "database-sg"
+  vpc_id      = aws_vpc.main.id
+
+  ingress {
+    from_port   = 3306
+    to_port     = 3306
+    protocol    = "tcp"
+    cidr_blocks = [aws_vpc.main.cidr_block]
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = {
+    Name        = "DatabaseSecurityGroup"
+    Environment = var.environment
+  }
+}

--- a/iac/modules/vpc/outputs.tf
+++ b/iac/modules/vpc/outputs.tf
@@ -1,0 +1,29 @@
+output "vpc_id" {
+  description = "ID of the VPC"
+  value       = aws_vpc.main.id
+}
+
+output "public_subnet_id" {
+  description = "ID of the public subnet"
+  value       = aws_subnet.public.id
+}
+
+output "private_subnet_id" {
+  description = "ID of the private subnet"
+  value       = aws_subnet.private.id
+}
+
+output "db_subnet_group_name" {
+  description = "Name of the DB subnet group"
+  value       = aws_db_subnet_group.main.name
+}
+
+output "database_security_group_id" {
+  description = "ID of the database security group"
+  value       = aws_security_group.database.id
+}
+
+output "internet_gateway_id" {
+  description = "ID of the internet gateway"
+  value       = aws_internet_gateway.main.id
+}

--- a/iac/modules/vpc/variables.tf
+++ b/iac/modules/vpc/variables.tf
@@ -1,0 +1,31 @@
+variable "cidr_block" {
+  description = "CIDR block for the VPC"
+  type        = string
+}
+
+variable "public_subnet_cidr" {
+  description = "CIDR block for the public subnet"
+  type        = string
+}
+
+variable "availability_zone" {
+  description = "Availability zone for the public subnet"
+  type        = string
+}
+
+variable "environment" {
+  description = "Environment name"
+  type        = string
+}
+
+variable "private_subnet_cidr" {
+  description = "CIDR block for the private subnet"
+  type        = string
+  default     = "10.0.2.0/24"
+}
+
+variable "private_availability_zone" {
+  description = "Availability zone for the private subnet"
+  type        = string
+  default     = "us-east-2b"
+}


### PR DESCRIPTION
Este pull request agrega el módulo de infraestructura de red (VPC) reutilizable para el proyecto, incluyendo:

- Creación de una VPC con soporte para DNS.
- Subred pública y privada en zonas de disponibilidad configurables.
- Internet Gateway asociado a la VPC.
- DB Subnet Group usando ambas subredes para alta disponibilidad de RDS.
- Security Group específico para la base de datos, permitiendo tráfico interno en el puerto 3306.
- Variables parametrizables para CIDR, zonas de disponibilidad y entorno.
- Outputs para IDs de recursos clave y nombres de grupos.

Esto permite reutilizar y aprovisionar la red base para los módulos de RDS y otros servicios dependientes de la infraestructura