### PR TITLE
feature: Integración de base de datos con RDS 

### DIFF
--- a/iac/main.tf
+++ b/iac/main.tf
@@ -164,32 +164,7 @@ module "rds_usuarios" {
   source               = "./modules/rds/usuarios"
   db_user              = "dbadmin"
   db_password          = "supersecure"
-  db_subnet_group_name = module.vpc.db_subnet_group_name
-  security_group_id    = module.vpc.database_security_group_id
-  environment          = var.environment
-}
-module "s3_public" {
-  source       = "./modules/s3_bucket/s3_public"
-  bucket_name  = "online-ready-public-${var.environment}"
-  environment  = var.environment
-}
-
-module "lambda_users" {
-  source         = "./modules/lambdas/users"
-  role_arn       = module.iam_lambda_users.role_arn
-  db_host        = module.rds_usuarios.endpoint
-  db_name        = module.rds_usuarios.name
-  db_user        = "admin"
-  db_password    = "supersecure"
-  s3_public_url  = "https://${module.s3_public.bucket_name}.s3.amazonaws.com"
-  environment    = var.environment
-}
-
-module "rds_curso_docente" {
-  source               = "./modules/rds/curso_docente"
-  db_user              = "dbadmin"
-  db_password          = "supersecure"
-  db_subnet_group_name = module.vpc.db_subnet_group_name
-  security_group_id    = module.vpc.database_security_group_id
+  db_subnet_group_name = module.vpc.db_subnet_group_name  
+  security_group_id    = module.vpc.database_security_group_id  
   environment          = var.environment
 }

--- a/iac/main.tf
+++ b/iac/main.tf
@@ -159,3 +159,12 @@ module "iam_lambda_files_manager" {
   dynamodb_table_arn = module.dynamodb_archivos.table_arn
   rds_instance_arn   = module.rds_usuarios.arn
 }
+
+module "rds_usuarios" {
+  source               = "./modules/rds/usuarios"
+  db_user              = "dbadmin"
+  db_password          = "supersecure"
+  db_subnet_group_name = module.vpc.db_subnet_group_name
+  security_group_id    = module.vpc.database_security_group_id
+  environment          = var.environment
+}

--- a/iac/main.tf
+++ b/iac/main.tf
@@ -168,3 +168,28 @@ module "rds_usuarios" {
   security_group_id    = module.vpc.database_security_group_id
   environment          = var.environment
 }
+module "s3_public" {
+  source       = "./modules/s3_bucket/s3_public"
+  bucket_name  = "online-ready-public-${var.environment}"
+  environment  = var.environment
+}
+
+module "lambda_users" {
+  source         = "./modules/lambdas/users"
+  role_arn       = module.iam_lambda_users.role_arn
+  db_host        = module.rds_usuarios.endpoint
+  db_name        = module.rds_usuarios.name
+  db_user        = "admin"
+  db_password    = "supersecure"
+  s3_public_url  = "https://${module.s3_public.bucket_name}.s3.amazonaws.com"
+  environment    = var.environment
+}
+
+module "rds_curso_docente" {
+  source               = "./modules/rds/curso_docente"
+  db_user              = "dbadmin"
+  db_password          = "supersecure"
+  db_subnet_group_name = module.vpc.db_subnet_group_name
+  security_group_id    = module.vpc.database_security_group_id
+  environment          = var.environment
+}

--- a/iac/modules/rds/curso_docente/main.tf
+++ b/iac/modules/rds/curso_docente/main.tf
@@ -1,0 +1,18 @@
+resource "aws_db_instance" "curso_docente_db" {
+  identifier             = "curso-docente-db"
+  engine                 = "postgres"
+  instance_class         = "db.t3.micro"
+  allocated_storage      = 20
+  db_name                = "OnlineReady"
+  username               = "dbadmin"
+  password               = var.db_password
+  publicly_accessible    = true
+  skip_final_snapshot    = true
+  db_subnet_group_name   = var.db_subnet_group_name
+  vpc_security_group_ids = [var.security_group_id]
+
+  tags = {
+    Name        = "CursoDocenteDB"
+    Environment = var.environment
+  }
+}

--- a/iac/modules/rds/curso_docente/outputs.tf
+++ b/iac/modules/rds/curso_docente/outputs.tf
@@ -1,0 +1,19 @@
+output "endpoint" {
+  description = "RDS instance endpoint"
+  value       = aws_db_instance.curso_docente_db.endpoint
+}
+
+output "name" {
+  description = "Database name"
+  value       = aws_db_instance.curso_docente_db.db_name
+}
+
+output "arn" {
+  description = "RDS instance ARN"
+  value       = aws_db_instance.curso_docente_db.arn
+}
+
+output "db_instance_id" {
+  description = "RDS instance ID"
+  value       = aws_db_instance.curso_docente_db.id
+}

--- a/iac/modules/rds/curso_docente/variables.tf
+++ b/iac/modules/rds/curso_docente/variables.tf
@@ -1,0 +1,8 @@
+variable "db_user" {}
+variable "db_password" {}
+variable "db_subnet_group_name" {
+  description = "Name of the DB subnet group"
+  type        = string
+}
+variable "security_group_id" {}
+variable "environment" {}

--- a/iac/modules/rds/usuarios/main.tf
+++ b/iac/modules/rds/usuarios/main.tf
@@ -1,0 +1,19 @@
+resource "aws_db_instance" "usuarios_db" {
+  identifier             = "online-ready-db"
+  engine                 = "postgres"
+  instance_class         = "db.t3.micro"
+  allocated_storage      = 20
+  db_name                   = "onlineready"
+  username               = "dbadmin"
+  password               = var.db_password
+  publicly_accessible    = true
+  skip_final_snapshot    = true
+  deletion_protection    = false
+  db_subnet_group_name   = var.db_subnet_group_name
+  vpc_security_group_ids = [var.security_group_id]
+
+  tags = {
+    Name        = "OnlineReadyRDS"
+    Environment = var.environment
+  }
+}

--- a/iac/modules/rds/usuarios/outputs.tf
+++ b/iac/modules/rds/usuarios/outputs.tf
@@ -1,0 +1,19 @@
+output "endpoint" {
+  description = "RDS instance endpoint"
+  value       = aws_db_instance.usuarios_db.endpoint
+}
+
+output "name" {
+  description = "Database name"
+  value       = aws_db_instance.usuarios_db.db_name
+}
+
+output "arn" {
+  description = "RDS instance ARN"
+  value       = aws_db_instance.usuarios_db.arn
+}
+
+output "db_instance_id" {
+  description = "RDS instance ID"
+  value       = aws_db_instance.usuarios_db.id
+}

--- a/iac/modules/rds/usuarios/variables.tf
+++ b/iac/modules/rds/usuarios/variables.tf
@@ -1,0 +1,8 @@
+variable "db_user" {}
+variable "db_password" {}
+variable "db_subnet_group_name" {
+  description = "Name of the DB subnet group"
+  type        = string
+}
+variable "security_group_id" {}
+variable "environment" {}


### PR DESCRIPTION
En este pull request se integró el módulo de RDS PostgreSQL para gestión de datos relacionales.
- Se aprovisionaron dos instancias RDS (`usuarios_db` y `curso_docente_db`) con PostgreSQL, incluyendo configuraciones de subred y grupo de seguridad.
- Se añadieron salidas para los detalles de las instancias RDS, como el endpoint, ARN y nombre de la base de datos.
- Se introdujeron variables para credenciales de base de datos, subredes y grupos de seguridad.
- Se actualizó el archivo principal de Terraform (iac/main.tf) para incluir nuevos módulos de CloudFront, S3, API Gateway, funciones Lambda, roles IAM, DynamoDB y RDS, mejorando la modularidad y reutilización.

