### PR TITLE
feature: Configuración de endpoints REST API con integración Lambda

### DIFF
--- a/iac/main.tf
+++ b/iac/main.tf
@@ -237,3 +237,20 @@ module "vpc" {
   private_availability_zone  = "us-east-2b"
   environment                = var.environment
 }
+
+module "endpoints" {
+  source = "./modules/endpoints"
+
+  # API Gateway existente
+  api_id                              = module.api_gateway.api_id
+  parent_id                           = module.api_gateway.root_resource_id
+  api_execution_arn                   = module.api_gateway.execution_arn 
+  
+  # Funciones Lambda
+  lambda_cursos_invoke_arn            = module.lambda_courses.invoke_arn
+  lambda_users_invoke_arn             = module.lambda_users.invoke_arn
+  lambda_files_manager_invoke_arn     = module.lambda_files_manager.invoke_arn
+  lambda_cursos_function_name         = module.lambda_courses.function_name
+  lambda_users_function_name          = module.lambda_users.function_name
+  lambda_files_manager_function_name  = module.lambda_files_manager.function_name
+}

--- a/iac/modules/endpoints/main.tf
+++ b/iac/modules/endpoints/main.tf
@@ -1,0 +1,99 @@
+# Recurso para la ruta "/api/cursos"
+resource "aws_api_gateway_resource" "cursos" {
+  rest_api_id = var.api_id
+  parent_id   = var.parent_id 
+  path_part   = "cursos"
+}
+
+# Método POST para "/api/cursos"
+resource "aws_api_gateway_method" "cursos_post" {
+  rest_api_id   = var.api_id
+  resource_id   = aws_api_gateway_resource.cursos.id
+  http_method   = "POST"
+  authorization = "AWS_IAM" # Use AWS_IAM for IAM-based authorization
+}
+
+# Integración de la ruta "/api/cursos" con la Lambda correspondiente
+resource "aws_api_gateway_integration" "cursos_post_integration" {
+  rest_api_id             = var.api_id 
+  resource_id             = aws_api_gateway_resource.cursos.id
+  http_method             = aws_api_gateway_method.cursos_post.http_method
+  integration_http_method = "POST"
+  type                    = "AWS_PROXY"
+  uri                     = var.lambda_cursos_invoke_arn
+}
+
+# Recurso para la ruta "/api/archivos"
+resource "aws_api_gateway_resource" "archivos" {
+  rest_api_id = var.api_id
+  parent_id   = var.parent_id
+  path_part   = "archivos"
+}
+
+# Método POST para "/api/archivos"
+resource "aws_api_gateway_method" "archivos_post" {
+  rest_api_id   = var.api_id
+  resource_id   = aws_api_gateway_resource.archivos.id
+  http_method   = "POST"
+  authorization = "AWS_IAM" # Use AWS_IAM for IAM-based authorization
+}
+
+# Integración de la ruta "/api/archivos" con la Lambda correspondiente
+resource "aws_api_gateway_integration" "archivos_post_integration" {
+  rest_api_id             = var.api_id  # Corregido de aws_api_gateway_rest_api.api.id
+  resource_id             = aws_api_gateway_resource.archivos.id
+  http_method             = aws_api_gateway_method.archivos_post.http_method
+  integration_http_method = "POST"
+  type                    = "AWS_PROXY"
+  uri                     = var.lambda_files_manager_invoke_arn
+}
+
+# Recurso para la ruta "/api/usuarios"
+resource "aws_api_gateway_resource" "usuarios" {
+  rest_api_id = var.api_id
+  parent_id   = var.parent_id
+  path_part   = "usuarios"
+}
+
+# Método POST para "/api/usuarios"
+resource "aws_api_gateway_method" "usuarios_post" {
+  rest_api_id   = var.api_id
+  resource_id   = aws_api_gateway_resource.usuarios.id
+  http_method   = "POST"
+  authorization = "AWS_IAM" # Use AWS_IAM for IAM-based authorization
+}
+
+# Integración de la ruta "/api/usuarios" con la Lambda correspondiente
+resource "aws_api_gateway_integration" "usuarios_post_integration" {
+  rest_api_id             = var.api_id
+  resource_id             = aws_api_gateway_resource.usuarios.id
+  http_method             = aws_api_gateway_method.usuarios_post.http_method
+  integration_http_method = "POST"
+  type                    = "AWS_PROXY"
+  uri                     = var.lambda_users_invoke_arn
+}
+
+# Permisos para que API Gateway pueda invocar las Lambdas
+resource "aws_lambda_permission" "allow_lambda_cursos" {
+  statement_id  = "AllowLambdaCursos"
+  action        = "lambda:InvokeFunction"
+  function_name = var.lambda_cursos_function_name
+  principal     = "apigateway.amazonaws.com"
+  source_arn    = "${var.api_execution_arn}/*/*"
+}
+
+resource "aws_lambda_permission" "allow_lambda_users" {
+  statement_id  = "AllowLambdaUsers"
+  action        = "lambda:InvokeFunction"
+  function_name = var.lambda_users_function_name
+  principal     = "apigateway.amazonaws.com"
+  source_arn    = "${var.api_execution_arn}/*/*"
+}
+
+resource "aws_lambda_permission" "allow_lambda_archivos" {
+  statement_id  = "AllowLambdaArchivos"
+  action        = "lambda:InvokeFunction"
+  function_name = var.lambda_files_manager_function_name
+  principal     = "apigateway.amazonaws.com"
+  source_arn    = "${var.api_execution_arn}/*/*"
+}

--- a/iac/modules/endpoints/outputs.tf
+++ b/iac/modules/endpoints/outputs.tf
@@ -1,0 +1,9 @@
+output "cursos_resource_id" {
+  description = "Resource ID for /cursos endpoint"
+  value       = aws_api_gateway_resource.cursos.id
+}
+
+output "usuarios_resource_id" {
+  description = "Resource ID for /usuarios endpoint"
+  value       = aws_api_gateway_resource.usuarios.id
+}

--- a/iac/modules/endpoints/variables.tf
+++ b/iac/modules/endpoints/variables.tf
@@ -1,0 +1,44 @@
+variable "api_id" {
+  description = "ID of the existing API Gateway"
+  type        = string
+}
+
+variable "api_execution_arn" {
+  description = "Execution ARN of the API Gateway"
+  type        = string
+}
+
+variable "parent_id" {
+  description = "Parent resource ID (root resource of API Gateway)"
+  type        = string
+}
+
+variable "lambda_cursos_invoke_arn" {
+  description = "ARN to invoke the cursos lambda function"
+  type        = string
+}
+
+variable "lambda_users_invoke_arn" {
+  description = "ARN to invoke the users lambda function"
+  type        = string
+}
+
+variable "lambda_files_manager_invoke_arn" {
+  description = "ARN to invoke the files manager lambda function"
+  type        = string
+}
+
+variable "lambda_cursos_function_name" {
+  description = "Name of the cursos lambda function"
+  type        = string
+}
+
+variable "lambda_users_function_name" {
+  description = "Name of the users lambda function"
+  type        = string
+}
+
+variable "lambda_files_manager_function_name" {
+  description = "Name of the files manager lambda function"
+  type        = string
+}


### PR DESCRIPTION
En este pull request se integraron mejoras en para el servicio de REST API, agregando el modulo de endpoints.
- Se añadieron los endpoints `/notify`, `/cursos`, `/archivos` y `/usuarios` con métodos POST e integraciones AWS_PROXY. Compatible con API Gateway existente. 
- Se configuró autorización basada en IAM para los endpoints `/cursos`, `/archivos` y `/usuarios`.
- Se integró  AWS_PROXY con funciones Lambda correspondientes.