### PR TITLE
feature: Módulo IAM Roles, roles reutilizables para Lambdas con acceso a S3, DynamoDB y RDS

### DIFF
--- a/iac/main.tf
+++ b/iac/main.tf
@@ -58,3 +58,11 @@ module "lambda_api_handler" {
   dynamodb_table_name = module.dynamodb_archivos.table_name
   environment         = var.environment
 }
+
+module "iam_roles" {
+  source = "./modules/iam_roles/iam_roles"
+  s3_bucket_arn      = module.s3_archivos.bucket_arn
+  dynamodb_table_arn = module.dynamodb_archivos.table_arn
+  rds_instance_arn   = module.rds_usuarios.arn 
+  environment        = var.environment
+}

--- a/iac/modules/iam_roles/iam_roles/main.tf
+++ b/iac/modules/iam_roles/iam_roles/main.tf
@@ -1,0 +1,19 @@
+module "lambda_api_handler_role" {
+  source = "../lambda_exec_role"
+  role_name = "lambda-api-handler-role"
+  
+  s3_bucket_arn            = var.s3_bucket_arn
+  dynamodb_table_arn       = var.dynamodb_table_arn
+  rds_instance_arn         = var.rds_instance_arn
+  extra_policy_statements  = []
+}
+
+module "lambda_notify_role" {
+  source = "../lambda_exec_role"
+  role_name = "lambda-notify-role"
+  
+  s3_bucket_arn            = var.s3_bucket_arn
+  dynamodb_table_arn       = var.dynamodb_table_arn
+  rds_instance_arn         = var.rds_instance_arn
+  extra_policy_statements  = []
+}

--- a/iac/modules/iam_roles/iam_roles/outputs.tf
+++ b/iac/modules/iam_roles/iam_roles/outputs.tf
@@ -1,0 +1,9 @@
+output "api_handler_role_arn" {
+  description = "ARN of the API handler Lambda role"
+  value       = module.lambda_api_handler_role.role_arn
+}
+
+output "lambda_notify_role_arn" {
+  description = "ARN of the Lambda notify role"
+  value       = module.lambda_notify_role.role_arn
+}

--- a/iac/modules/iam_roles/iam_roles/variables.tf
+++ b/iac/modules/iam_roles/iam_roles/variables.tf
@@ -1,0 +1,60 @@
+variable "environment" {
+  description = "Environment name (e.g., dev, staging, prod)"
+  type        = string
+}
+
+variable "s3_bucket_arn" {
+  description = "ARN of the main S3 bucket for Lambda access"
+  type        = string
+  default     = ""
+}
+
+variable "dynamodb_table_arn" {
+  description = "ARN of the main DynamoDB table for Lambda access"
+  type        = string
+  default     = ""
+}
+
+variable "rds_instance_arn" {
+  description = "ARN of the RDS instance for Lambda access"
+  type        = string
+  default     = ""
+}
+
+variable "project_name" {
+  description = "Name of the project for resource naming"
+  type        = string
+  default     = "cursos-online"
+}
+
+# Variables específicas para diferentes tipos de roles
+variable "enable_s3_access" {
+  description = "Whether to enable S3 access for Lambda roles"
+  type        = bool
+  default     = true
+}
+
+variable "enable_dynamodb_access" {
+  description = "Whether to enable DynamoDB access for Lambda roles"
+  type        = bool
+  default     = true
+}
+
+variable "enable_rds_access" {
+  description = "Whether to enable RDS access for Lambda roles"
+  type        = bool
+  default     = true
+}
+
+# Variables opcionales para personalización de roles específicos
+variable "api_handler_extra_policies" {
+  description = "Extra policy statements for API handler role"
+  type        = list(any)
+  default     = []
+}
+
+variable "notify_extra_policies" {
+  description = "Extra policy statements for notify role"
+  type        = list(any)
+  default     = []
+}

--- a/iac/modules/iam_roles/lambda_exec_role/main.tf
+++ b/iac/modules/iam_roles/lambda_exec_role/main.tf
@@ -1,0 +1,48 @@
+resource "aws_iam_role" "lambda_role" {
+  name = var.role_name
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17",
+    Statement = [
+      {
+        Action = "sts:AssumeRole",
+        Effect = "Allow",
+        Principal = {
+          Service = "lambda.amazonaws.com"
+        }
+      }
+    ]
+  })
+}
+
+resource "aws_iam_role_policy" "lambda_policy" {
+  name = "${var.role_name}_policy"
+  role = aws_iam_role.lambda_role.id
+
+  policy = jsonencode({
+    Version = "2012-10-17",
+    Statement = [
+      {
+        Effect   = "Allow",
+        Action   = ["logs:CreateLogGroup", "logs:CreateLogStream", "logs:PutLogEvents"],
+        Resource = "arn:aws:logs:*:*:*"
+      },
+      # Solo agregar statements si las variables no están vacías
+      {
+        Effect   = "Allow",
+        Action   = ["s3:PutObject", "s3:GetObject"],
+        Resource = var.s3_bucket_arn != "" ? "${var.s3_bucket_arn}/*" : "*"
+      },
+      {
+        Effect   = "Allow",
+        Action   = ["dynamodb:PutItem", "dynamodb:GetItem", "dynamodb:Query", "dynamodb:Scan"],
+        Resource = var.dynamodb_table_arn != "" ? var.dynamodb_table_arn : "*"
+      },
+      {
+        Effect   = "Allow",
+        Action   = ["rds:DescribeDBInstances", "rds:ExecuteStatement"],
+        Resource = var.rds_instance_arn != "" ? var.rds_instance_arn : "*"
+      }
+    ]
+  })
+}

--- a/iac/modules/iam_roles/lambda_exec_role/outputs.tf
+++ b/iac/modules/iam_roles/lambda_exec_role/outputs.tf
@@ -1,0 +1,9 @@
+output "role_name" {
+  description = "Name of the IAM role"
+  value       = aws_iam_role.lambda_role.name
+}
+
+output "role_arn" {
+  description = "ARN of the IAM role"
+  value       = aws_iam_role.lambda_role.arn
+}

--- a/iac/modules/iam_roles/lambda_exec_role/variables.tf
+++ b/iac/modules/iam_roles/lambda_exec_role/variables.tf
@@ -1,0 +1,28 @@
+variable "role_name" {
+  description = "Name of the IAM role"
+  type        = string
+}
+
+variable "s3_bucket_arn" {
+  description = "ARN of the S3 bucket"
+  type        = string
+  default     = ""
+}
+
+variable "dynamodb_table_arn" {
+  description = "ARN of the DynamoDB table"
+  type        = string
+  default     = ""
+}
+
+variable "rds_instance_arn" {
+  description = "ARN of the RDS instance"
+  type        = string
+  default     = ""
+}
+
+variable "extra_policy_statements" {
+  description = "Additional policy statements"
+  type        = list(any)
+  default     = []
+}


### PR DESCRIPTION
Este pull request introduce el módulo `iam_roles` para la gestión centralizada de roles IAM reutilizables para funciones Lambda, incluyendo:

- **Módulo `lambda_exec_role`**: Define la lógica base para crear roles IAM con políticas para acceso a CloudWatch Logs, S3, DynamoDB y RDS, además de permitir políticas adicionales personalizadas.
- **Módulo `iam_roles`**: Implementa dos roles específicos:
  - `lambda_api_handler_role`
  - `lambda_notify_role`
- Variables parametrizables para ARNs de recursos, entorno y políticas extra.
- Outputs de los ARNs de los roles creados para integración con otros módulos.
- Integración del módulo en el archivo principal (`main.tf`) para aprovisionar los roles y asociarlos a las Lambdas correspondientes.

Esto facilita la gestión segura y reutilizable de permisos para las funciones Lambda